### PR TITLE
Add 'dist' to codespell skip list for codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.svg,package-lock.json,*.css,.codespellrc
+skip = .git*,*.svg,package-lock.json,*.css,.codespellrc,dist
 check-hidden = true
 # ignore-regex = 
 # ignore-words-list =


### PR DESCRIPTION
this is the location to tune codespell config to make it green again.